### PR TITLE
fix pagination traslation

### DIFF
--- a/layout/_partial/archive.ejs
+++ b/layout/_partial/archive.ejs
@@ -26,8 +26,8 @@
 <% if (page.total > 1){ %>
   <nav id="page-nav">
     <%- paginator({
-      prev_text: "&laquo; __('prev')",
-      next_text: "__('next') &raquo;"
+      'prev_text': "&laquo; "+__('prev'),
+      'next_text': __('next')+" &raquo;"
     }) %>
   </nav>
 <% } %>


### PR DESCRIPTION
syntax `__(xxx)` won't work when wrapped in string
